### PR TITLE
Проверка текстовых слоев на разные стили + поддержка FigJam и Figma Slides

### DIFF
--- a/code.ts
+++ b/code.ts
@@ -948,7 +948,7 @@ function findTextNodes(): TextNode[] {
 }
 
 // Применяем к текстовым узлам Типограф
-async function applyTypographToTextNodes() {
+async function applyTypographToTextNodes(preserveStyles: boolean = true) {
   const textNodes = findTextNodes();
 
   await Promise.all(textNodes.map(async (node) => {
@@ -965,7 +965,7 @@ async function applyTypographToTextNodes() {
     if (originalText === typographResult) return;
 
     try {
-      if (node.fontName !== figma.mixed) {
+      if (node.fontName !== figma.mixed && !hasMixedTextVisualParams(node, originalText.length)) {
         // В текстовом узле один стиль
         await figma.loadFontAsync(node.fontName);
         node.characters = typographResult;
@@ -991,6 +991,34 @@ async function applyTypographToTextNodes() {
 // ⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛ Схранение текстовых стилей ⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛
 // ⁛⁛⁛⁛⁛⁛ Автор кода Alexey Kalinin sonniydsgn https://github.com/sonniydsgn ⁛⁛⁛⁛⁛⁛
 // ⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛⁛
+function hasMixedTextVisualParams(node: TextNode, textLength: number): boolean {
+  if (textLength === 0) return false;
+
+  const styledSegments = node.getStyledTextSegments([
+    'fontName',
+    'fontSize',
+    'fontWeight',
+    'fontStyle',
+    'fills',
+    'fillStyleId',
+    'textStyleId',
+    'textCase',
+    'textDecoration',
+    'letterSpacing',
+    'lineHeight',
+    'listOptions',
+    'listSpacing',
+    'indentation',
+    'paragraphIndent',
+    'paragraphSpacing',
+    'hyperlink',
+    'openTypeFeatures',
+    'textStyleOverrides',
+  ], 0, textLength);
+
+  return styledSegments.length > 1;
+}
+
 /**
  * Применяет изменения текста через insertCharacters/deleteCharacters
  * вместо node.characters = ... чтобы сохранить стили

--- a/code.ts
+++ b/code.ts
@@ -948,7 +948,7 @@ function findTextNodes(): TextNode[] {
 }
 
 // Применяем к текстовым узлам Типограф
-async function applyTypographToTextNodes(preserveStyles: boolean = true) {
+async function applyTypographToTextNodes() {
   const textNodes = findTextNodes();
 
   await Promise.all(textNodes.map(async (node) => {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,9 @@
   "enableProposedApi": false,
   "documentAccess": "dynamic-page",
   "editorType": [
-    "figma"
+    "figma",
+    "figjam",
+    "slides"
   ],
   "ui": "ui.html",
   "networkAccess": {


### PR DESCRIPTION
В текущем решении есть проблема, что типографе при исправлении текста смотрит только на разные шрифты. Кроме этого параметра есть ещё куча других, которые нужно проверять: цвет текста, стили, толщина, ссылки, списки и другие    

Не стал добавлять в изменения `code.js`, оставил только основные правки